### PR TITLE
Add timing of unit tests

### DIFF
--- a/MOxUnit/@MOxUnitFunctionHandleTestCase/run.m
+++ b/MOxUnit/@MOxUnitFunctionHandleTestCase/run.m
@@ -16,6 +16,7 @@ function result=run(obj,result)
 %
 % NNO 2015
 
+    start_tic = tic;
     try
         passed=false;
         try
@@ -32,16 +33,16 @@ function result=run(obj,result)
                 end
 
                 reason=e.message((last_newline_pos+1):end);
-                result=addSkip(result, obj, reason);
+                result=addSkip(result, obj, reason, toc(start_tic));
             else
-                result=addFailure(result, obj, e);
+                result=addFailure(result, obj, e, toc(start_tic));
             end
         end
 
         if passed
-            result=addSuccess(result, obj);
+            result=addSuccess(result, obj, toc(start_tic));
         end
     catch
         e=lasterror();
-        result=addError(result, obj, e);
+        result=addError(result, obj, e, toc(start_tic));
     end

--- a/MOxUnit/@MOxUnitTestResult/MOxUnitTestResult.m
+++ b/MOxUnit/@MOxUnitTestResult/MOxUnitTestResult.m
@@ -34,5 +34,6 @@ function obj=MOxUnitTestResult(verbosity,stream)
     s.skips=cell(0);
     s.successes=cell(0);
     s.testsRun=0;
+    s.duration=0;
     obj=class(s,'MOxUnitTestResult');
 

--- a/MOxUnit/@MOxUnitTestResult/addError.m
+++ b/MOxUnit/@MOxUnitTestResult/addError.m
@@ -1,4 +1,4 @@
-function obj=addError(obj,t,e)
+function obj=addError(obj,t,e,dur)
 % Add test case error to a MoxUnitTestResult instance
 %
 % obj=addError(obj,t,e)
@@ -7,6 +7,7 @@ function obj=addError(obj,t,e)
 %   obj             MOxUnitTestResult instance.
 %   t               MoxUnitTestCase that gave an error.
 %   e               Exception associated with the error.
+%   dur             Duration of runtime until error (in seconds).
 %
 % Output:
 %   obj             MOxUnitTestResult instance with the error added.
@@ -16,4 +17,5 @@ function obj=addError(obj,t,e)
 
     obj.failures{end+1}={t,e};
     obj.testsRun=obj.testsRun+1;
+    obj.duration=obj.duration+dur;
     report(obj,'e','Error',t);

--- a/MOxUnit/@MOxUnitTestResult/addFailure.m
+++ b/MOxUnit/@MOxUnitTestResult/addFailure.m
@@ -1,4 +1,4 @@
-function obj=addFailure(obj,t,e)
+function obj=addFailure(obj,t,e,dur)
 % Add test case failure to a MoxUnitTestResult instance
 %
 % obj=addError(obj,t,e)
@@ -7,6 +7,7 @@ function obj=addFailure(obj,t,e)
 %   obj             MOxUnitTestResult instance.
 %   t               MoxUnitTestCase that gave a failure.
 %   e               Exception associated with the failure.
+%   dur             Duration of runtime until failure (in seconds).
 %
 % Output:
 %   obj             MOxUnitTestResult instance with the failure added.
@@ -15,4 +16,5 @@ function obj=addFailure(obj,t,e)
 
     obj.failures{end+1}={t,e};
     obj.testsRun=obj.testsRun+1;
+    obj.duration=obj.duration+dur;
     report(obj,'F','FAILED',t);

--- a/MOxUnit/@MOxUnitTestResult/addSkip.m
+++ b/MOxUnit/@MOxUnitTestResult/addSkip.m
@@ -1,4 +1,4 @@
-function obj=addSkip(obj,t,reason)
+function obj=addSkip(obj,t,reason,dur)
 % Add test case skip to a MoxUnitTestResult instance
 %
 % obj=addError(obj,t,e)
@@ -7,6 +7,7 @@ function obj=addSkip(obj,t,reason)
 %   obj             MOxUnitTestResult instance.
 %   t               MoxUnitTestCase that gave an error.
 %   reason          String describing the reason why a test was skipped.
+%   dur             Duration of runtime until skipped (in seconds).
 %
 % Output:
 %   obj             MOxUnitTestResult instance with the skipped test
@@ -16,5 +17,7 @@ function obj=addSkip(obj,t,reason)
 
     obj.skips{end+1}={t,reason};
     obj.testsRun=obj.testsRun+1;
+    obj.duration=obj.duration+dur;
     report(obj,'s','SKIP',t);
+
 

--- a/MOxUnit/@MOxUnitTestResult/addSuccess.m
+++ b/MOxUnit/@MOxUnitTestResult/addSuccess.m
@@ -1,4 +1,4 @@
-function obj=addSuccess(obj,t)
+function obj=addSuccess(obj,t,dur)
 % Add test case success (pass) to a MoxUnitTestResult instance
 %
 % obj=addError(obj,t,e)
@@ -6,6 +6,7 @@ function obj=addSuccess(obj,t)
 % Inputs:
 %   obj             MOxUnitTestResult instance.
 %   t               MoxUnitTestCase that gave a success.
+%   dur             Duration of runtime (in seconds).
 %
 % Output:
 %   obj             MOxUnitTestResult instance with the test success added.
@@ -14,5 +15,6 @@ function obj=addSuccess(obj,t)
 
     obj.successes{end+1}=t;
     obj.testsRun=obj.testsRun+1;
+    obj.duration=obj.duration+dur;
     report(obj,'.','passed',t);
 


### PR DESCRIPTION
- Each unit test is timed with `tic` and `toc`.
- The cumulative duration for the testsuite is tracked and added to
  the results object.
